### PR TITLE
Add Hicdex API to the CSP

### DIFF
--- a/src/utils/html.js
+++ b/src/utils/html.js
@@ -179,6 +179,7 @@ export function injectCSPMetaTagIntoHTML(html) {
       https://api.etherscan.io
       https://api.thegraph.com
       https://*.tzkt.io
+      https://api.hicdex.com
       https://api.tzstats.com
       https://*.wikidata.org
       https://*.coinmarketcap.com


### PR DESCRIPTION
Request PR to include https://api.hicdex.com/ in the CSP to allow Interactive OBJKTs to query the Hicdex.com GraphiQL API.